### PR TITLE
add more useful options

### DIFF
--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -204,6 +204,7 @@ for notebook in $notebooks; do
 
     # Run the notebook:
     $jupyter nbconvert $kernel_option \
+        --ExecutePreprocessor.startup_timeout=120 \
         --ExecutePreprocessor.timeout=1200 \
         --to $outputformat \
         --execute $filename &> $logfile

--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -148,7 +148,7 @@ fi
 
 # set target output branch
 target="${output_branch_default}"
-if [ "$branch" -ne 'master' ]; then
+if [ "$branch" != "master" ]; then
     target="${target}/${branch}"
 fi
 

--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -204,7 +204,7 @@ for notebook in $notebooks; do
 
     # Run the notebook:
     $jupyter nbconvert $kernel_option \
-        --ExecutePreprocessor.startup_timeout=120 \
+        --ExecutePreprocessor.startup_timeout=300 \
         --ExecutePreprocessor.timeout=1200 \
         --to $outputformat \
         --execute $filename &> $logfile

--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -150,7 +150,7 @@ fi
 # set target output branch
 target="${output_branch_default}"
 if [ "$branch" != "master" ]; then
-    target="${target}/${branch}"
+    target="${target}-${branch}"
 fi
 
 # set html or notebook option
@@ -158,7 +158,7 @@ if [ $html -gt 0 ]; then
     echo "Making static HTML pages..."
     outputformat="HTML"
     ext="html"
-    target="${target}/html"
+    target="${target}-html"
 else
     echo "Rendering notebooks..."
     outputformat="notebook"

--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -148,7 +148,7 @@ fi
 
 # set target output branch
 target="${output_branch_default}"
-if [ "$branch" -ne 'master']; then
+if [ "$branch" -ne 'master' ]; then
     target="${target}/${branch}"
 fi
 

--- a/beavis-ci.sh
+++ b/beavis-ci.sh
@@ -17,7 +17,7 @@
 #
 # OPTIONAL INPUTS:
 #   -h --help        Print this header
-#   -b --branch      Test the notebooks in a dev branch. Default is "master". Outputs will go to "rendered/$branch"
+#   -b --branch      Test the notebooks in a dev branch. Default is "master". Outputs will go to "rendered-$branch"
 #   -k --kernel      Enforce a specific kernel
 #   -n --notebooks   Run on notebooks that match this. Default is '*'
 #   -w --working-dir Working directory. Default is '.beavis'


### PR DESCRIPTION
This PR adds a few useful options:
- `-k` (`--kernel`) to enforce the use of a certain kernel (useful for testing dev kernels)
- `-n` (`--notebooks`) to run a subset of notebooks

This PR also change the behavior when `-b` (`--branch`) is specified: it will now push to a branch named `rendered/${branch}` so that it will not conflict with the rendering of the master branch. This is useful for checking out a notebook on a PR (e.g., https://github.com/LSSTDESC/DC2-analysis/blob/rendered-u/JulienPeloton/spark-data-access/tutorials/object_spark_1_intro.nbconvert.ipynb) 

cc @heather999 